### PR TITLE
Fix grouping svg shapes to avoid the crash on re-render

### DIFF
--- a/src/line-chart.js
+++ b/src/line-chart.js
@@ -37,7 +37,7 @@ class LineChart extends AbstractChart {
         );
       });
     });
-    return output;
+    return <G>{output}</G>;
   };
 
   renderShadow = config => {
@@ -75,7 +75,7 @@ class LineChart extends AbstractChart {
         />
       );
     });
-    return output;
+    return <G>{output}</G>;
   };
 
   renderLine = config => {
@@ -108,7 +108,7 @@ class LineChart extends AbstractChart {
       );
     });
 
-    return output;
+    return <G>{output}</G>;
   };
 
   getBezierLinePoints = (dataset, config) => {
@@ -161,7 +161,7 @@ class LineChart extends AbstractChart {
         />
       );
     });
-    return output;
+    return <G>{output}</G>;
   };
 
   renderBezierShadow = config => {
@@ -183,7 +183,7 @@ class LineChart extends AbstractChart {
         />
       );
     });
-    return output;
+    return <G>{output}</G>;
   };
 
   render() {


### PR DESCRIPTION
This fixes the issue when updating the data passed into the line chart.
The cause of this issue was that there are some SVG lines getting rendered without getting grouped, which caused the error with **"Removed child count (0) was not what we expected (1)"**